### PR TITLE
fix li style

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -158,10 +158,6 @@ const GlobalStyle = createGlobalStyle`
   h3 {
     margin-top: 50px;
   }
-
-  li {
-    list-style: none;
-  }
 `
 
 const Layout: React.FC<Props> = ({ children, meta, headlines, type = 'normal' }) => {

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -20,16 +20,19 @@ const Title = styled.div`
 const OuterUl = styled.ul`
   padding: 0px 12px 8px 12px;
   margin-top: 8px;
+  list-style: none;
   font-size: ${Const.SIZE.FONT.LARGE};
 `
 
 const InnerUl = styled.ul`
   padding-left: 24px;
+  list-style: none;
   font-size: ${Const.SIZE.FONT.LARGE};
 `
 
 const Li = styled.li`
   padding: 4px 0;
+  list-style: none;
   &:hover {
     background: ${Const.COLOR.BACKGROUND.BASE};
   }


### PR DESCRIPTION
グローバルで li に list-style: none; を設定したら記事ページにも影響受けてしまうため戻す