### PR TITLE
fix: improve article title positioning and truncation on top page

### DIFF
--- a/src/components/TopPostItem.tsx
+++ b/src/components/TopPostItem.tsx
@@ -30,15 +30,15 @@ const PostItem: React.FC<Props> = ({
       <Link href={url}>
         <div 
           role="link"
-          className="w-[270px] h-[300px] bg-bg-panel box-border rounded-lg cursor-pointer transition-all duration-100 overflow-hidden flex flex-row items-end bg-no-repeat bg-auto hover:opacity-60 hover:border-transparent hover:shadow-[0_10px_20px_rgba(0,0,0,0.3)]"
+          className="w-[270px] h-[300px] bg-bg-panel box-border rounded-lg cursor-pointer transition-all duration-100 overflow-hidden flex flex-row items-end bg-no-repeat bg-auto hover:opacity-60 hover:border-transparent hover:shadow-[0_10px_20px_rgba(0,0,0,0.3)] relative"
           style={{
             backgroundImage: `url(${imgPath})`,
             backgroundSize: 'auto 100%'
           }}
         >
-          <div className="bg-black/60 w-full h-[150px] p-24">
+          <div className="bg-black/60 w-full h-[170px] p-24 absolute bottom-0 left-0">
             <p className="m-0 text-font-topDate">{createdDate}</p>
-            <p className="m-0 text-24 text-font-white break-words line-clamp-3">{name}</p>
+            <p className="m-0 text-24 text-font-white break-words line-clamp-3 overflow-hidden text-ellipsis">{name}</p>
           </div>
         </div>
       </Link>


### PR DESCRIPTION
Fixes issue #60 where article titles on the top page were being cut off.

## Changes:
- Increased overlay height from 150px to 170px to provide more space
- Position overlay absolutely to better control placement
- Add relative positioning to parent container
- Enhance text truncation with overflow-hidden and text-ellipsis
- Maintain line-clamp-3 for 3-line limit as requested

Closes #60

Generated with [Claude Code](https://claude.ai/code)