### PR TITLE
トップページの記事サムネイルオーバーレイとテキスト位置を調整

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,31 +7,31 @@
       
 	<url>
 		<loc>https://ok-log.net/articles/2020-09-06-mdx-test/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 
 	<url>
 		<loc>https://ok-log.net/articles/2020-09-25-sample1/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 
 	<url>
 		<loc>https://ok-log.net/articles/2021-06-15-new-img-fromat/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 
 	<url>
 		<loc>https://ok-log.net/articles/2021-06-15-syntax-highlight/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 
 	<url>
 		<loc>https://ok-log.net/articles/2021-07-15-about-meta-tag/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 
 	<url>
 		<loc>https://ok-log.net/articles/2021-11-01-when-to-use/</loc>
-		<lastmod>2025-06-04</lastmod>
+		<lastmod>2025-06-05</lastmod>
 	</url>
 </urlset>

--- a/src/components/TopPostItem.tsx
+++ b/src/components/TopPostItem.tsx
@@ -36,9 +36,9 @@ const PostItem: React.FC<Props> = ({
             backgroundSize: 'auto 100%'
           }}
         >
-          <div className="bg-black/60 w-full h-[170px] p-24 absolute bottom-0 left-0">
+          <div className="bg-black/60 w-full h-[200px] px-24 py-16 absolute bottom-0 left-0 flex flex-col justify-start">
             <p className="m-0 text-font-topDate">{createdDate}</p>
-            <p className="m-0 text-24 text-font-white break-words line-clamp-3 overflow-hidden text-ellipsis">{name}</p>
+            <p className="m-0 mt-8 text-24 text-font-white break-words line-clamp-3 overflow-hidden text-ellipsis">{name}</p>
           </div>
         </div>
       </Link>


### PR DESCRIPTION
## Summary
- トップページの記事一覧のサムネイルオーバーレイを下端まで広げました
- オーバーレイ内のテキスト（日付とタイトル）の位置を上部に調整し、テキストが切れる問題を解決しました

## Test plan
- [ ] トップページを表示し、記事サムネイルのオーバーレイが下端まで表示されることを確認
- [ ] 記事タイトルが切れずに表示されることを確認
- [ ] 各種ブラウザで表示崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)